### PR TITLE
Adds optional object configuration in first parameter to controls

### DIFF
--- a/opc.js
+++ b/opc.js
@@ -6,14 +6,13 @@ class OPC {
 	}
 
 	static slider(variableNameOrConfig, value, min = 0, max = null, step = null) {
-		let variableName
-		let label, description
+		let variableName, label, description;
 		if (typeof variableNameOrConfig === 'object') {
 			variableName = variableNameOrConfig.name;
 			value = variableNameOrConfig.value;
-			min = variableNameOrConfig.min ?? 0;
-			max = variableNameOrConfig.max ?? null;
-			step = variableNameOrConfig ?? null;
+			min = variableNameOrConfig.min ?? min;
+			max = variableNameOrConfig.max ?? max;
+			step = variableNameOrConfig ?? step;
 			label = variableNameOrConfig.label;
 			description = variableNameOrConfig.description;
 		} else {
@@ -39,11 +38,10 @@ class OPC {
 	}
 
 	static toggle(variableNameOrConfig, value = true) {
-		let variableName
-		let label, description
+		let variableName, label, description;
 		if (typeof variableNameOrConfig === 'object') {
 			variableName = variableNameOrConfig.name;
-			value = variableNameOrConfig.value ?? true;
+			value = variableNameOrConfig.value ?? value;
 			label = variableNameOrConfig.label;
 			description = variableNameOrConfig.description;
 		} else {
@@ -65,12 +63,11 @@ class OPC {
 	}
 
 	static palette(variableNameOrConfig, options, value = null) {
-		let variableName
-		let label, description
+		let variableName, label, description;
 		if (typeof variableNameOrConfig === 'object') {
 			variableName = variableNameOrConfig.name;
 			options = variableNameOrConfig.options;
-			value = variableNameOrConfig.value ?? null;
+			value = variableNameOrConfig.value ?? value;
 			label = variableNameOrConfig.label;
 			description = variableNameOrConfig.description;
 		} else {
@@ -92,11 +89,10 @@ class OPC {
 		return this.initVariable(this.options[variableName]);
 	}
 	static color(variableNameOrConfig, value = '#333333') {
-		let variableName
-		let label, description
+		let variableName, label, description;
 		if (typeof variableNameOrConfig === 'object') {
 			variableName = variableNameOrConfig.name;
-			value = variableNameOrConfig.value ?? null;
+			value = variableNameOrConfig.value ?? value;
 			label = variableNameOrConfig.label;
 			description = variableNameOrConfig.description;
 		} else {
@@ -118,13 +114,12 @@ class OPC {
 	}
 
 	static text(variableNameOrConfig, value, placeholder = null, maxChars = 1000) {
-		let variableName
-		let label, description
+		let variableName, label, description;
 		if (typeof variableNameOrConfig === 'object') {
 			variableName = variableNameOrConfig.name;
-			value = variableNameOrConfig.value ?? null;
-			placeholder = variableNameOrConfig.placeholder ?? null;
-			maxChars = variableNameOrConfig.maxChars ?? 1000;
+			value = variableNameOrConfig.value;
+			placeholder = variableNameOrConfig.placeholder ?? placeholder;
+			maxChars = variableNameOrConfig.maxChars ?? maxChars;
 			label = variableNameOrConfig.label;
 			description = variableNameOrConfig.description;
 		} else {
@@ -145,12 +140,12 @@ class OPC {
 		}
 		return this.initVariable(this.options[variableName]);
 	}
-	static button(variableNameOrConfig, buttonText) {
-		let variableName
-		let description
+	static button(variableNameOrConfig, value = 'Click Me!') {
+		let variableName, label, description;
 		if (typeof variableNameOrConfig === 'object') {
 			variableName = variableNameOrConfig.name;
-			buttonText = variableNameOrConfig.text;
+			value = variableNameOrConfig.value ?? value;
+			label = variableNameOrConfig.label ?? label;
 			description = variableNameOrConfig.description;
 		} else {
 			variableName = variableNameOrConfig;
@@ -165,8 +160,7 @@ class OPC {
 		this.options[variableName] = {
 			name: variableName,
 			type: 'button',
-			value: buttonText,
-			description
+			value, label, description
 		}
 		return this.initVariable(this.options[variableName]);
 	}

--- a/opc.js
+++ b/opc.js
@@ -5,7 +5,20 @@ class OPC {
 		this.collapsed = false;
 	}
 
-	static slider(variableName, value, min = 0, max = null, step = null) {
+	static slider(variableNameOrConfig, value, min = 0, max = null, step = null) {
+		let variableName
+		let label, description
+		if (typeof variableNameOrConfig === 'object') {
+			variableName = variableNameOrConfig.name;
+			value = variableNameOrConfig.value;
+			min = variableNameOrConfig.min ?? 0;
+			max = variableNameOrConfig.max ?? null;
+			step = variableNameOrConfig ?? null;
+			label = variableNameOrConfig.label;
+			description = variableNameOrConfig.description;
+		} else {
+			variableName = variableNameOrConfig;
+		}
 		//check existing params
 		let url = new URL(document.location.href);
 		if (url && url.searchParams.has(variableName)) {
@@ -20,15 +33,22 @@ class OPC {
 		this.options[variableName] = {
 			name: variableName,
 			type: 'slider',
-			value: value,
-			min: min,
-			max: max,
-			step: step
+			min, max, value, step, label, description
 		}
 		return this.initVariable(this.options[variableName]);
 	}
 
-	static toggle(variableName, value = true) {
+	static toggle(variableNameOrConfig, value = true) {
+		let variableName
+		let label, description
+		if (typeof variableNameOrConfig === 'object') {
+			variableName = variableNameOrConfig.name;
+			value = variableNameOrConfig.value ?? true;
+			label = variableNameOrConfig.label;
+			description = variableNameOrConfig.description;
+		} else {
+			variableName = variableNameOrConfig;
+		}
 		//check existing params
 		let url = new URL(document.location.href);
 		if (url && url.searchParams.has(variableName)) {
@@ -39,12 +59,23 @@ class OPC {
 		this.options[variableName] = {
 			name: variableName,
 			type: 'toggle',
-			value: value
+			value, label, description
 		}
 		return this.initVariable(this.options[variableName]);
 	}
 
-	static palette(variableName, options, value = null) {
+	static palette(variableNameOrConfig, options, value = null) {
+		let variableName
+		let label, description
+		if (typeof variableNameOrConfig === 'object') {
+			variableName = variableNameOrConfig.name;
+			options = variableNameOrConfig.options;
+			value = variableNameOrConfig.value ?? null;
+			label = variableNameOrConfig.label;
+			description = variableNameOrConfig.description;
+		} else {
+			variableName = variableNameOrConfig;
+		}
 		//check existing params
 		let url = new URL(document.location.href);
 		if (url && url.searchParams.has(variableName)) {
@@ -56,11 +87,21 @@ class OPC {
 			name: variableName,
 			type: 'palette',
 			value: value ?? options[0],
-			options: options
+			options, label, description
 		}
 		return this.initVariable(this.options[variableName]);
 	}
-	static color(variableName, value = '#333333') {
+	static color(variableNameOrConfig, value = '#333333') {
+		let variableName
+		let label, description
+		if (typeof variableNameOrConfig === 'object') {
+			variableName = variableNameOrConfig.name;
+			value = variableNameOrConfig.value ?? null;
+			label = variableNameOrConfig.label;
+			description = variableNameOrConfig.description;
+		} else {
+			variableName = variableNameOrConfig;
+		}
 		//check existing params
 		let url = new URL(document.location.href);
 		if (url && url.searchParams.has(variableName)) {
@@ -71,12 +112,24 @@ class OPC {
 		this.options[variableName] = {
 			name: variableName,
 			type: 'color',
-			value: value
+			value, label, description
 		}
 		return this.initVariable(this.options[variableName]);
 	}
 
-	static text(variableName, value, placeholder = null, maxChars = 1000) {
+	static text(variableNameOrConfig, value, placeholder = null, maxChars = 1000) {
+		let variableName
+		let label, description
+		if (typeof variableNameOrConfig === 'object') {
+			variableName = variableNameOrConfig.name;
+			value = variableNameOrConfig.value ?? null;
+			placeholder = variableNameOrConfig.placeholder ?? null;
+			maxChars = variableNameOrConfig.maxChars ?? 1000;
+			label = variableNameOrConfig.label;
+			description = variableNameOrConfig.description;
+		} else {
+			variableName = variableNameOrConfig;
+		}
 		//check existing params
 		let url = new URL(document.location.href);
 		if (url && url.searchParams.has(variableName)) {
@@ -87,13 +140,21 @@ class OPC {
 		this.options[variableName] = {
 			name: variableName,
 			type: 'text',
-			value: value,
-			placeholder: placeholder,
-			max: maxChars
+			max: maxChars,
+			value, placeholder, label, description
 		}
 		return this.initVariable(this.options[variableName]);
 	}
-	static button(variableName, buttonText) {
+	static button(variableNameOrConfig, buttonText) {
+		let variableName
+		let description
+		if (typeof variableNameOrConfig === 'object') {
+			variableName = variableNameOrConfig.name;
+			buttonText = variableNameOrConfig.text;
+			description = variableNameOrConfig.description;
+		} else {
+			variableName = variableNameOrConfig;
+		}
 		//check existing params
 		let url = new URL(document.location.href);
 		if (url && url.searchParams.has(variableName)) {
@@ -104,7 +165,8 @@ class OPC {
 		this.options[variableName] = {
 			name: variableName,
 			type: 'button',
-			value: buttonText
+			value: buttonText,
+			description
 		}
 		return this.initVariable(this.options[variableName]);
 	}

--- a/opc.js
+++ b/opc.js
@@ -189,45 +189,42 @@ class OPC {
 		return true;
 	}
 
-
-	static set = function (variableName, value) {
+	static set (variableName, value) {
 		window[variableName] = value;
 	}
-	static buttonPressed = function (variableName, value) {
+
+	static buttonPressed (variableName, value) {
 		OPC.options[variableName].value = value;
 		if (typeof window.buttonPressed == 'function') {
 			window.buttonPressed(variableName, value);
 		}
 
 	}
-	static buttonReleased = function (variableName, value) {
+	static buttonReleased (variableName, value) {
 		OPC.options[variableName].value = value;
 		if (typeof window.buttonReleased == 'function') {
 			window.buttonReleased(variableName, value);
 		}
 
 	}
-	static set = function (variableName, value) {
-		window[variableName] = value;
-	}
 
-	static collapse = function () {
+	static collapse () {
 		OPC.collapsed = true;
 		OPC.callParentFunction('OPC_collapsed', OPC.collapsed);
 	}
-	static expand = function () {
+	static expand () {
 		OPC.collapsed = false;
 		OPC.callParentFunction('OPC_collapsed', OPC.collapsed);
 	}
-	static delete = function (variableName) {
-		if (OPC.options[variableName]){ 
+	static delete (variableName) {
+		if (OPC.options[variableName]){
 			delete OPC.options[variableName];
 			delete window.variableName;
 		}
 		OPC.callParentFunction('OPC_delete', variableName);
 	}
 
-	static callParentFunction = function (functionName, arg = {}) {
+	static callParentFunction (functionName, arg = {}) {
 		// console.log(arg);
 		try {
 			//try sending as is
@@ -237,7 +234,6 @@ class OPC {
 			}, '*');
 		} catch (error) {
 			console.log('postMessage', error);
-
 		}
 	}
 


### PR DESCRIPTION
This change adds the ability to send a configuration object instead of individual settings to the control declaration functions (`slider`, `toggle`, `palette`, `color`, `text` and `button`), and additionally it accepts two new properties in the config parameter: `label` and `description` (with the exception of text, which has no label)

This change doesn't affect the existing functionality and the methods with the old API signature continue to behave as usual, as tested both in a standalone client (see upcoming PR for standalone library), and in the OP sketch https://openprocessing.org/sketch/1946497

The `label` and `description` parameters are passed but ignored by current OP vue client