### PR TITLE
OPC standalone client

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,12 @@
+<html>
+    <head>
+    <script src="https://cdn.jsdelivr.net/npm/p5@1.4.1/lib/p5.js" type="text/javascript"></script>
+    <script src="../opc.js" type="text/javascript"></script>
+    <script src="../opc-client.js" type="text/javascript"></script>
+    <script src="mySketch.js" type="text/javascript"></script>
+    </head>
+    <link rel="stylesheet" href="../opc-client.css">
+<body>
+</body>
+
+</html>

--- a/example/mySketch.js
+++ b/example/mySketch.js
@@ -1,0 +1,116 @@
+// OPC SETUP
+// You can easily create dynamic variables to use in your sketch.
+// Read full documentation at https://github.com/msawired/OPC
+
+// Example: Create a variable "radius" that can be controlled via a slider, with default value 250
+OPC.slider('radius', 250);
+
+//you can also provide the arguments in a single object, with optional additional arguments [label, description]
+OPC.slider({
+	name: 'stroke_weight',
+	value: 3,
+	min: 1,
+	max: 10,
+	step: 1,
+	label: 'Circle Border',
+	description: 'Changes the border size of the circle'
+});
+
+// OPC.toggle('has_stroke', true); //short version
+OPC.toggle({
+	name: 'has_stroke',
+	value: true,
+	label: 'Border Enabled?',
+	description: 'Adds a border on the circles'
+});
+
+OPC.color('bg_color', '#ffffff'); //native color selector
+
+// Some color palette options to choose from
+let myPalettes = [
+	["#eabfcb", "#c191a1", "#a4508b", "#5f0a87", "#2f004f"],
+	["#c3dfe0", "#bcd979", "#9dad6f", "#7d6d61", "#5e574d"],
+	["#4464ad", "#a4b0f5", "#f58f29", "#7d4600", "#466995"]
+];
+OPC.palette('palette', myPalettes);
+
+// text input
+OPC.text('my_text', '', 'Enter Title');
+
+// simple select (dropdown) version with array
+// OPC.select('circles', [5,4,3,2,1]);
+
+// advanced select with key->value pairs. Key is used as label in UI.
+OPC.select('circles', {"A Lot": 5,"Few": 3,"One": 1});
+
+// for buttons, see ButtonPressed and ButtonReleased functions below
+OPC.button('pauseButton', 'Press & Hold to Pause');
+
+
+
+// REST OF THE SKETCH BELOW
+
+let paused = false;
+let freakDistanceMax = 120;
+let freak = 0;
+
+
+function setup() {
+	createCanvas(windowWidth, windowHeight);
+	strokeWeight(5);
+	frameRate(5);
+}
+
+function draw() {
+	if(!paused){
+		radius++; //any updates to variables in your code will also be reflected on OPC interface
+	}
+	background(bg_color);
+	stroke_weight ? strokeWeight(stroke_weight) : strokeWeight(1);
+	has_stroke ? stroke('#333') : noStroke();
+	fill(palette[0]);
+	circle(width / 5 * 0.5, height / 2, radius);
+
+	if (circles >= 2) {
+		fill(palette[1]);
+		circle(width / 5 * 1.5, height / 2, radius);
+	}
+	if (circles >= 3) {
+		fill(palette[2]);
+		circle(width / 5 * 2.5, height / 2, radius);
+	}
+	if (circles >= 4) {
+		fill(palette[3]);
+		circle(width / 5 * 3.5, height / 2, radius);
+	}
+	if (circles >= 5) {
+		fill(palette[4]);
+		circle(width / 5 * 4.5, height / 2, radius);
+	}
+
+	fill('#333');
+	textAlign('center');
+	textSize(100);
+	text(my_text, width / 2, height / 2 + 30);
+}
+
+//parameterChanged function is used every time a parameter is updated.
+function parameterChanged(variableName, newValue) {
+	// print(variableName,newValue);
+}
+
+//BUTTON FUNCTIONS
+//buttonPressed function is used every time a button is pressed.
+function buttonPressed(variableName) {
+	//you can check variableName if you have multiple buttons
+	if (variableName == 'pauseButton') {
+		paused = true;
+	}
+}
+
+//buttonReleased function is used every time a button is released.
+function buttonReleased(variableName) {
+	if (variableName == 'pauseButton') {
+		paused = false;
+	}
+}

--- a/opc-client.css
+++ b/opc-client.css
@@ -1,0 +1,87 @@
+/*  This is an example client that can be used to test the OPC. You can customize this to adjust the UI to your needs. */
+
+#opc-control-panel {
+	position: absolute;
+	top: 0px;
+	right: 10px;
+	padding: 1em;
+	background-color: #ffffff;
+	color: #333;
+	border: 1px solid #000000;
+	border-radius: 10px;
+	z-index: 9999;
+	width: 300px;
+	display: flex;
+	font-family: Montserrat, Helvetica, Arial, sans-serif;
+	font-size: 13px;
+	box-shadow: 0 2px 4px #333;
+	flex-direction: column;
+}
+
+#opc-control-panel .opc-control-wrapper {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 1em;
+}
+
+#opc-control-panel .opc-control-wrapper:last-child {
+	margin-bottom: 0;
+}
+
+#opc-control-panel .opc-control {
+	display: flex;
+	align-items: center;
+	flex-direction: row;
+	padding: 0 0.5em;
+	min-height: 2em;
+}
+
+#opc-control-panel .opc-control label {
+	flex: 0 0 40%;
+}
+
+#opc-control-panel .opc-description {
+	color: #666;
+	margin-bottom: 0.3em;
+	font-size: 0.9em;
+}
+
+#opc-control-panel input {
+	display: block;
+	margin-left: auto;
+}
+
+#opc-control-panel input[type=number] {
+	width: 3em;
+	padding: 5px;
+	margin-right: 3px;
+}
+
+#opc-control-panel input[type=checkbox] {
+	transform: scale(1.2);
+}
+
+#opc-control-panel input[type=text] {
+	flex: 1;
+}
+
+#opc-control-panel input[type=button] {
+	flex: 1;
+}
+
+#opc-control-panel .opc-palette-container {
+	flex: 1;
+}
+
+#opc-control-panel .opc-palette {
+	display: none;
+	min-height: 1.5em;
+}
+
+#opc-control-panel .opc-palette.active {
+	display: flex;
+}
+
+#opc-control-panel .opc-palette .opc-palette-color {
+	flex: 1;
+}

--- a/opc-client.js
+++ b/opc-client.js
@@ -6,7 +6,13 @@ if (window.OPC || typeof OPC === "function") {
 
   // Delay the construction of the elements until DOM is loaded
   let delay = (fn) => {
-    document.addEventListener("DOMContentLoaded", fn, false);
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+      // In OP, this is loaded after the document is fully loaded, execute immediately
+      fn()
+    } else {
+      // In standalone, wait for the document DOM to load
+      document.addEventListener("DOMContentLoaded", fn, false);
+    }
   }
 
   delay(() => {

--- a/opc-client.js
+++ b/opc-client.js
@@ -42,17 +42,29 @@ if (window.OPC || typeof OPC === "function") {
         box-shadow: 2px 2px 4px #999;
         flex-direction: column;
       }
+      #opc-control-panel .opc-control-wrapper {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 1em;
+      }
+      #opc-control-panel .opc-control-wrapper:last-child {
+        margin-bottom: 0;
+      }
       #opc-control-panel .opc-control {
         display: flex;
         align-items: center;
-        margin-bottom: 0.7em;
-      }
-      #opc-control-panel .opc-control:last-child {
-        margin-bottom: 0;
+        flex-direction: row;
+        padding: 0 0.5em;
+        min-height: 2em;
       }
       #opc-control-panel .opc-control label {
         flex: 0 0 40%;
         text-transform: uppercase;
+      }
+      #opc-control-panel .opc-description {
+        color: #666;
+        margin-bottom: 0.3em;
+        font-size: 0.9em;
       }
       #opc-control-panel input {
         display: block;
@@ -93,14 +105,29 @@ if (window.OPC || typeof OPC === "function") {
 
   let createId = () => Math.random().toString(36).substring(2, 6);
 
+  let createControlContainer = (description) => {
+    let wrapper = document.createElement("div");
+    wrapper.classList.add("opc-control-wrapper");
+
+    if (description) {
+      let desc = document.createElement("div");
+      desc.classList.add("opc-description");
+      desc.textContent = description;
+      wrapper.appendChild(desc);
+    }
+    let inputContainer = document.createElement("div");
+    inputContainer.classList.add("opc-control");
+    wrapper.appendChild(inputContainer);
+    return [wrapper, inputContainer];
+  };
+
   let _opcCreateSlider = (option, controlsElem) => {
     let id = "slider-" + createId();
-    let container = document.createElement("div");
-    container.classList.add("opc-control");
+    let [wrapper, container] = createControlContainer(option.description);
 
     let label = document.createElement("label");
     label.setAttribute("for", id);
-    label.textContent = option.name;
+    label.textContent = option.label ?? option.name;
 
     const numInput = document.createElement("input");
     numInput.id = "num-" + id;
@@ -136,17 +163,16 @@ if (window.OPC || typeof OPC === "function") {
     container.appendChild(label);
     container.appendChild(numInput);
     container.appendChild(slider);
-    controlsElem.appendChild(container);
+    controlsElem.appendChild(wrapper);
   };
 
   let _opcCreateToggle = (option, controlsElem) => {
     let id = "slider-" + createId();
-    let container = document.createElement("div");
-    container.classList.add("opc-control");
+    let [wrapper, container] = createControlContainer(option.description);
 
     let label = document.createElement("label");
     label.setAttribute("for", id);
-    label.textContent = option.name;
+    label.textContent = option.label ?? option.name;
 
     const toggleButton = document.createElement("input");
     toggleButton.id = id;
@@ -165,17 +191,16 @@ if (window.OPC || typeof OPC === "function") {
 
     container.appendChild(label);
     container.appendChild(toggleButton);
-    controlsElem.appendChild(container);
+    controlsElem.appendChild(wrapper);
   }
 
   let _opcCreateText = (option, controlsElem) => {
     let id = 'text-' + createId();
-    let container = document.createElement("div");
-    container.classList.add("opc-control");
+    let [wrapper, container] = createControlContainer(option.description);
 
     let label = document.createElement("label");
     label.setAttribute("for", id);
-    label.textContent = option.name;
+    label.textContent = option.label ?? option.name;
 
     const textInput = document.createElement("input");
     textInput.id = id;
@@ -196,17 +221,16 @@ if (window.OPC || typeof OPC === "function") {
 
     container.appendChild(label);
     container.appendChild(textInput);
-    controlsElem.appendChild(container);
+    controlsElem.appendChild(wrapper);
   }
 
   let _opcCreateColorPicker = (option, controlsElem) => {
     let id = 'text-' + createId();
-    let container = document.createElement("div");
-    container.classList.add("opc-control");
+    let [wrapper, container] = createControlContainer(option.description);
 
     let label = document.createElement("label");
     label.setAttribute("for", id);
-    label.textContent = option.name;
+    label.textContent = option.label ?? option.name;
 
     const colorInput = document.createElement("input");
     colorInput.id = id;
@@ -220,13 +244,12 @@ if (window.OPC || typeof OPC === "function") {
     // TODO: Implement sync back of color variable. May be tricky for non RGB schemes
     container.appendChild(label);
     container.appendChild(colorInput);
-    controlsElem.appendChild(container);
+    controlsElem.appendChild(wrapper);
   }
 
   let _opcCreateButton = (option, controlsElem) => {
     let id = 'text-' + createId();
-    let container = document.createElement("div");
-    container.classList.add("opc-control");
+    let [wrapper, container] = createControlContainer(option.description);
 
     const buttonElem = document.createElement("input");
     buttonElem.id = id;
@@ -247,24 +270,23 @@ if (window.OPC || typeof OPC === "function") {
     });
 
     container.appendChild(buttonElem);
-    controlsElem.appendChild(container);
+    controlsElem.appendChild(wrapper);
   }
 
   let _opcCreatePalettePicker = (option, controlsElem) => {
     let id = 'text-' + createId();
-    let container = document.createElement("div");
-    container.classList.add("opc-control");
+    let [wrapper, container] = createControlContainer(option.description);
 
     let label = document.createElement("label");
     label.setAttribute("for", id);
-    label.textContent = option.name;
+    label.textContent = option.label ?? option.name;
 
     let selected = option.options.indexOf(option.value);
 
     const paletteElem = document.createElement("div");
     paletteElem.classList.add("opc-palette-container");
     let palettes = [];
-    for (let palette of option.options) {
+    for (let palette of option.options) { // noprotect
       let paletteContainer = document.createElement("div");
       paletteContainer.classList.add("opc-palette");
       if (option.value === palette) {
@@ -275,7 +297,6 @@ if (window.OPC || typeof OPC === "function") {
         colorElem.classList.add("opc-palette-color");
         colorElem.style.backgroundColor = color;
         paletteContainer.append(colorElem);
-        colorElem.addEventListener;
       }
       palettes.push(paletteContainer);
       paletteContainer.addEventListener('click', () => {
@@ -292,7 +313,7 @@ if (window.OPC || typeof OPC === "function") {
     // TODO: Implement sync back of palette variable
     container.appendChild(label);
     container.appendChild(paletteElem);
-    controlsElem.appendChild(container);;
+    controlsElem.appendChild(wrapper);
   }
 
   window.addEventListener('message', (event) => {

--- a/opc-client.js
+++ b/opc-client.js
@@ -1,28 +1,28 @@
 if (window.OPC || typeof OPC === "function") {
-  let controlsElem
+  let controlsElem;
 
   // Hold events triggered when value changes
-  let opcControlEvents = {}
+  let opcControlEvents = {};
 
   // Delay the construction of the elements until DOM is loaded
   let delay = (fn) => {
-    document.addEventListener("DOMContentLoaded", fn, false)
+    document.addEventListener("DOMContentLoaded", fn, false);
   }
 
   delay(() => {
     // Create controls element
-    controlsElem = document.createElement("div")
+    controlsElem = document.createElement("div");
 
-    controlsElem.id = "opc-control-panel"
-    document.body.appendChild(controlsElem)
+    controlsElem.id = "opc-control-panel";
+    document.body.appendChild(controlsElem);
 
     // Insert custom CSS. Perhaps this will go better in an optional CSS
-    const style = document.createElement("style")
+    const style = document.createElement("style");
     style.textContent = `
       #opc-control-panel {
         position: absolute;
-        top: 500px;
-        right: 20px;
+        top: 0px;
+        right: 10px;
         padding: 1em;
         background-color: #ffffff;
         color: #333;
@@ -52,258 +52,250 @@ if (window.OPC || typeof OPC === "function") {
         display: block;
         margin-left: auto;
       }
-
       #opc-control-panel input[type=number] {
         width: 3em;
         padding: 5px;
         margin-right: 3px;
       }
-
       #opc-control-panel input[type=checkbox] {
         transform: scale(1.2);
       }
-
       #opc-control-panel input[type=text] {
         flex: 1;
       }
-
       #opc-control-panel input[type=button] {
         flex: 1;
         padding: 0.2em 0.5em;
       }
-
       #opc-control-panel .opc-palette-container {
         flex: 1;
         height: 1.5em;
       }
-
       #opc-control-panel .opc-palette {
         display: none;
         height: 100%;
       }
-
       #opc-control-panel .opc-palette.active {
         display: flex;
       }
-
       #opc-control-panel .opc-palette .opc-palette-color {
         flex: 1;
       }
-    `
-    document.head.appendChild(style)
+    `;
+    document.head.appendChild(style);
   })
 
-  let createId = () => Math.random().toString(36).substring(2, 6)
+  let createId = () => Math.random().toString(36).substring(2, 6);
 
   let _opcCreateSlider = (option, controlsElem) => {
-    let id = "slider-" + createId()
-    let container = document.createElement("div")
-    container.classList.add("opc-control")
+    let id = "slider-" + createId();
+    let container = document.createElement("div");
+    container.classList.add("opc-control");
 
-    let label = document.createElement("label")
-    label.setAttribute("for", id)
-    label.textContent = option.name
+    let label = document.createElement("label");
+    label.setAttribute("for", id);
+    label.textContent = option.name;
 
-    const numInput = document.createElement("input")
-    numInput.id = "num-" + id
-    numInput.type = "number"
-    numInput.min = option.min
-    numInput.max = option.max
-    numInput.value = option.value
+    const numInput = document.createElement("input");
+    numInput.id = "num-" + id;
+    numInput.type = "number";
+    numInput.min = option.min;
+    numInput.max = option.max;
+    numInput.value = option.value;
 
-    const slider = document.createElement("input")
-    slider.id = id
-    slider.type = "range"
-    slider.min = option.min
-    slider.max = option.max
-    slider.value = option.value
-    slider.step = option.step
+    const slider = document.createElement("input");
+    slider.id = id;
+    slider.type = "range";
+    slider.min = option.min;
+    slider.max = option.max;
+    slider.value = option.value;
+    slider.step = option.step;
 
     numInput.addEventListener('input', () => {
-      slider.value = numInput.value
-      OPC.set(option.name, numInput.value)
-    })
+      slider.value = numInput.value;
+      OPC.set(option.name, numInput.value);
+    });
 
     slider.addEventListener('input', () => {
-      numInput.value = slider.value
-      OPC.set(option.name, slider.value)
-    })
+      numInput.value = slider.value;
+      OPC.set(option.name, slider.value);
+    });
 
-    opcControlEvents[option.name] ||= []
+    opcControlEvents[option.name] ||= [];
     opcControlEvents[option.name].push((v) => {
-      numInput.value = v
-      slider.value = v
-    })
+      numInput.value = v;
+      slider.value = v;
+    });
 
-    container.appendChild(label)
-    container.appendChild(numInput)
-    container.appendChild(slider)
-    controlsElem.appendChild(container)
-  }
+    container.appendChild(label);
+    container.appendChild(numInput);
+    container.appendChild(slider);
+    controlsElem.appendChild(container);
+  };
 
   let _opcCreateToggle = (option, controlsElem) => {
-    let id = "slider-" + createId()
-    let container = document.createElement("div")
-    container.classList.add("opc-control")
+    let id = "slider-" + createId();
+    let container = document.createElement("div");
+    container.classList.add("opc-control");
 
-    let label = document.createElement("label")
-    label.setAttribute("for", id)
-    label.textContent = option.name
+    let label = document.createElement("label");
+    label.setAttribute("for", id);
+    label.textContent = option.name;
 
-    const toggleButton = document.createElement("input")
-    toggleButton.id = id
-    toggleButton.type = "checkbox"
-    toggleButton.classList.add("opc-toggle")
-    toggleButton.checked = !!option.value
+    const toggleButton = document.createElement("input");
+    toggleButton.id = id;
+    toggleButton.type = "checkbox";
+    toggleButton.classList.add("opc-toggle");
+    toggleButton.checked = !!option.value;
 
     toggleButton.addEventListener('change', () => {
-      OPC.set(option.name, toggleButton.checked)
-    })
+      OPC.set(option.name, toggleButton.checked);
+    });
 
-    opcControlEvents[option.name] ||= []
+    opcControlEvents[option.name] ||= [];
     opcControlEvents[option.name].push((v) => {
-      toggleButton.checked = v
-    })
+      toggleButton.checked = v;
+    });
 
-    container.appendChild(label)
-    container.appendChild(toggleButton)
-    controlsElem.appendChild(container)
+    container.appendChild(label);
+    container.appendChild(toggleButton);
+    controlsElem.appendChild(container);
   }
 
   let _opcCreateText = (option, controlsElem) => {
-    let id = 'text-' + createId()
-    let container = document.createElement("div")
-    container.classList.add("opc-control")
+    let id = 'text-' + createId();
+    let container = document.createElement("div");
+    container.classList.add("opc-control");
 
-    let label = document.createElement("label")
-    label.setAttribute("for", id)
-    label.textContent = option.name
+    let label = document.createElement("label");
+    label.setAttribute("for", id);
+    label.textContent = option.name;
 
-    const textInput = document.createElement("input")
-    textInput.id = id
-    textInput.type = "text"
-    textInput.maxLength = option.max
-    textInput.minLength = 0
-    textInput.placeholder = option.placeholder
-    textInput.value = option.value
+    const textInput = document.createElement("input");
+    textInput.id = id;
+    textInput.type = "text";
+    textInput.maxLength = option.max;
+    textInput.minLength = 0;
+    textInput.placeholder = option.placeholder;
+    textInput.value = option.value;
 
     textInput.addEventListener('input', () => {
-      OPC.set(option.name, textInput.value)
+      OPC.set(option.name, textInput.value);
     })
 
-    opcControlEvents[option.name] ||= []
+    opcControlEvents[option.name] ||= [];
     opcControlEvents[option.name].push((v) => {
-      textInput.value = v
-    })
+      textInput.value = v;
+    });
 
-    container.appendChild(label)
-    container.appendChild(textInput)
-    controlsElem.appendChild(container)
+    container.appendChild(label);
+    container.appendChild(textInput);
+    controlsElem.appendChild(container);
   }
 
   let _opcCreateColorPicker = (option, controlsElem) => {
-    let id = 'text-' + createId()
-    let container = document.createElement("div")
-    container.classList.add("opc-control")
+    let id = 'text-' + createId();
+    let container = document.createElement("div");
+    container.classList.add("opc-control");
 
-    let label = document.createElement("label")
-    label.setAttribute("for", id)
-    label.textContent = option.name
+    let label = document.createElement("label");
+    label.setAttribute("for", id);
+    label.textContent = option.name;
 
-    const colorInput = document.createElement("input")
-    colorInput.id = id
-    colorInput.type = "color"
-    colorInput.value = option.value
+    const colorInput = document.createElement("input");
+    colorInput.id = id;
+    colorInput.type = "color";
+    colorInput.value = option.value;
 
     colorInput.addEventListener('input', () => {
-      OPC.set(option.name, colorInput.value)
-    })
+      OPC.set(option.name, colorInput.value);
+    });
 
     // TODO: Implement sync back of color variable. May be tricky for non RGB schemes
-    container.appendChild(label)
-    container.appendChild(colorInput)
-    controlsElem.appendChild(container)
+    container.appendChild(label);
+    container.appendChild(colorInput);
+    controlsElem.appendChild(container);
   }
 
   let _opcCreateButton = (option, controlsElem) => {
-    let id = 'text-' + createId()
-    let container = document.createElement("div")
-    container.classList.add("opc-control")
+    let id = 'text-' + createId();
+    let container = document.createElement("div");
+    container.classList.add("opc-control");
 
-    const buttonElem = document.createElement("input")
-    buttonElem.id = id
-    buttonElem.type = "button"
-    buttonElem.value = option.value
+    const buttonElem = document.createElement("input");
+    buttonElem.id = id;
+    buttonElem.type = "button";
+    buttonElem.value = option.value;
 
     buttonElem.addEventListener('touchstart', () => {
-      OPC.buttonPressed(option.name, buttonElem.value)
-    })
+      OPC.buttonPressed(option.name, buttonElem.value);
+    });
     buttonElem.addEventListener('mousedown', () => {
-      OPC.buttonPressed(option.name, buttonElem.value)
-    })
+      OPC.buttonPressed(option.name, buttonElem.value);
+    });
     buttonElem.addEventListener('touchend', () => {
-      OPC.buttonReleased(option.name, buttonElem.value)
-    })
+      OPC.buttonReleased(option.name, buttonElem.value);
+    });
     buttonElem.addEventListener('click', () => {
-      OPC.buttonReleased(option.name, buttonElem.value)
-    })
+      OPC.buttonReleased(option.name, buttonElem.value);
+    });
 
-    container.appendChild(buttonElem)
-    controlsElem.appendChild(container)
+    container.appendChild(buttonElem);
+    controlsElem.appendChild(container);
   }
 
   let _opcCreatePalettePicker = (option, controlsElem) => {
-    let id = 'text-' + createId()
-    let container = document.createElement("div")
-    container.classList.add("opc-control")
+    let id = 'text-' + createId();
+    let container = document.createElement("div");
+    container.classList.add("opc-control");
 
-    let label = document.createElement("label")
-    label.setAttribute("for", id)
-    label.textContent = option.name
+    let label = document.createElement("label");
+    label.setAttribute("for", id);
+    label.textContent = option.name;
 
-    let selected = option.options.indexOf(option.value)
+    let selected = option.options.indexOf(option.value);
 
-    const paletteElem = document.createElement("div")
-    paletteElem.classList.add("opc-palette-container")
-    let palettes = []
+    const paletteElem = document.createElement("div");
+    paletteElem.classList.add("opc-palette-container");
+    let palettes = [];
     for (let palette of option.options) {
-      let paletteContainer = document.createElement("div")
-      paletteContainer.classList.add("opc-palette")
+      let paletteContainer = document.createElement("div");
+      paletteContainer.classList.add("opc-palette");
       if (option.value === palette) {
-        paletteContainer.classList.add("active")
+        paletteContainer.classList.add("active");
       }
       for (let color of palette) {
-        let colorElem = document.createElement("div")
-        colorElem.classList.add("opc-palette-color")
-        colorElem.style.backgroundColor = color
-        paletteContainer.append(colorElem)
-        colorElem.addEventListener
+        let colorElem = document.createElement("div");
+        colorElem.classList.add("opc-palette-color");
+        colorElem.style.backgroundColor = color;
+        paletteContainer.append(colorElem);
+        colorElem.addEventListener;
       }
-      palettes.push(paletteContainer)
+      palettes.push(paletteContainer);
       paletteContainer.addEventListener('click', () => {
-        selected = (selected + 1) % option.options.length
+        selected = (selected + 1) % option.options.length;
         for (let p of palettes) {
-          p.classList.remove("active")
+          p.classList.remove("active");
         }
-        palettes[selected].classList.add("active")
-        OPC.set(option.name, option.options[selected])
-      })
-      paletteElem.append(paletteContainer)
+        palettes[selected].classList.add("active");
+        OPC.set(option.name, option.options[selected]);
+      });
+      paletteElem.append(paletteContainer);
     }
 
     // TODO: Implement sync back of palette variable
-    container.appendChild(label)
-    container.appendChild(paletteElem)
-    controlsElem.appendChild(container)
+    container.appendChild(label);
+    container.appendChild(paletteElem);
+    controlsElem.appendChild(container);;
   }
 
   window.addEventListener('message', (event) => {
     try {
       if (event.data && event.data.messageType === 'OPC') {
-        let listeners = opcControlEvents[event.data.message.name]
+        let listeners = opcControlEvents[event.data.message.name];
         if (listeners) {
           for (let listener of listeners) {
-            listener(event.data.message.value)
+            listener(event.data.message.value);
           }
         }
       }
@@ -313,31 +305,31 @@ if (window.OPC || typeof OPC === "function") {
   })
 
   // Decorate OPC functions
-  _opcInitVariable = OPC.initVariable
+  let _opcInitVariable = OPC.initVariable;
   OPC.initVariable = (option) => {
     delay(() => {
-      _opcInitVariable.call(OPC, option)
+      _opcInitVariable.call(OPC, option);
       switch (option.type) {
         case "slider":
-          _opcCreateSlider(option, controlsElem)
-          break
+          _opcCreateSlider(option, controlsElem);
+          break;
         case "toggle":
-          _opcCreateToggle(option, controlsElem)
-          break
+          _opcCreateToggle(option, controlsElem);
+          break;
         case "text":
-          _opcCreateText(option, controlsElem)
-          break
+          _opcCreateText(option, controlsElem);
+          break;
         case "color":
-          _opcCreateColorPicker(option, controlsElem)
-          break
+          _opcCreateColorPicker(option, controlsElem);
+          break;
         case "button":
-          _opcCreateButton(option, controlsElem)
-          break
+          _opcCreateButton(option, controlsElem);
+          break;
         case "palette":
-          _opcCreatePalettePicker(option, controlsElem)
-          break
+          _opcCreatePalettePicker(option, controlsElem);
+          break;
         default:
-          console.warn(`OPC Control type ${option.type} not supported`)
+          console.warn(`OPC Control type ${option.type} not supported`);
       }
     })
   }

--- a/opc-client.js
+++ b/opc-client.js
@@ -1,0 +1,344 @@
+if (window.OPC || typeof OPC === "function") {
+  let controlsElem
+
+  // Hold events triggered when value changes
+  let opcControlEvents = {}
+
+  // Delay the construction of the elements until DOM is loaded
+  let delay = (fn) => {
+    document.addEventListener("DOMContentLoaded", fn, false)
+  }
+
+  delay(() => {
+    // Create controls element
+    controlsElem = document.createElement("div")
+
+    controlsElem.id = "opc-control-panel"
+    document.body.appendChild(controlsElem)
+
+    // Insert custom CSS. Perhaps this will go better in an optional CSS
+    const style = document.createElement("style")
+    style.textContent = `
+      #opc-control-panel {
+        position: absolute;
+        top: 500px;
+        right: 20px;
+        padding: 1em;
+        background-color: #ffffff;
+        color: #333;
+        border: 1px solid #000000;
+        border-radius: 10px;
+        z-index: 9999;
+        width: 300px;
+        display: flex;
+        font-family: Montserrat, Helvetica, Arial, sans-serif;
+        font-size: 13px;
+        box-shadow: 2px 2px 4px #999;
+        flex-direction: column;
+      }
+      #opc-control-panel .opc-control {
+        display: flex;
+        align-items: center;
+        margin-bottom: 0.7em;
+      }
+      #opc-control-panel .opc-control:last-child {
+        margin-bottom: 0;
+      }
+      #opc-control-panel .opc-control label {
+        flex: 0 0 40%;
+        text-transform: uppercase;
+      }
+      #opc-control-panel input {
+        display: block;
+        margin-left: auto;
+      }
+
+      #opc-control-panel input[type=number] {
+        width: 3em;
+        padding: 5px;
+        margin-right: 3px;
+      }
+
+      #opc-control-panel input[type=checkbox] {
+        transform: scale(1.2);
+      }
+
+      #opc-control-panel input[type=text] {
+        flex: 1;
+      }
+
+      #opc-control-panel input[type=button] {
+        flex: 1;
+        padding: 0.2em 0.5em;
+      }
+
+      #opc-control-panel .opc-palette-container {
+        flex: 1;
+        height: 1.5em;
+      }
+
+      #opc-control-panel .opc-palette {
+        display: none;
+        height: 100%;
+      }
+
+      #opc-control-panel .opc-palette.active {
+        display: flex;
+      }
+
+      #opc-control-panel .opc-palette .opc-palette-color {
+        flex: 1;
+      }
+    `
+    document.head.appendChild(style)
+  })
+
+  let createId = () => Math.random().toString(36).substring(2, 6)
+
+  let _opcCreateSlider = (option, controlsElem) => {
+    let id = "slider-" + createId()
+    let container = document.createElement("div")
+    container.classList.add("opc-control")
+
+    let label = document.createElement("label")
+    label.setAttribute("for", id)
+    label.textContent = option.name
+
+    const numInput = document.createElement("input")
+    numInput.id = "num-" + id
+    numInput.type = "number"
+    numInput.min = option.min
+    numInput.max = option.max
+    numInput.value = option.value
+
+    const slider = document.createElement("input")
+    slider.id = id
+    slider.type = "range"
+    slider.min = option.min
+    slider.max = option.max
+    slider.value = option.value
+    slider.step = option.step
+
+    numInput.addEventListener('input', () => {
+      slider.value = numInput.value
+      OPC.set(option.name, numInput.value)
+    })
+
+    slider.addEventListener('input', () => {
+      numInput.value = slider.value
+      OPC.set(option.name, slider.value)
+    })
+
+    opcControlEvents[option.name] ||= []
+    opcControlEvents[option.name].push((v) => {
+      numInput.value = v
+      slider.value = v
+    })
+
+    container.appendChild(label)
+    container.appendChild(numInput)
+    container.appendChild(slider)
+    controlsElem.appendChild(container)
+  }
+
+  let _opcCreateToggle = (option, controlsElem) => {
+    let id = "slider-" + createId()
+    let container = document.createElement("div")
+    container.classList.add("opc-control")
+
+    let label = document.createElement("label")
+    label.setAttribute("for", id)
+    label.textContent = option.name
+
+    const toggleButton = document.createElement("input")
+    toggleButton.id = id
+    toggleButton.type = "checkbox"
+    toggleButton.classList.add("opc-toggle")
+    toggleButton.checked = !!option.value
+
+    toggleButton.addEventListener('change', () => {
+      OPC.set(option.name, toggleButton.checked)
+    })
+
+    opcControlEvents[option.name] ||= []
+    opcControlEvents[option.name].push((v) => {
+      toggleButton.checked = v
+    })
+
+    container.appendChild(label)
+    container.appendChild(toggleButton)
+    controlsElem.appendChild(container)
+  }
+
+  let _opcCreateText = (option, controlsElem) => {
+    let id = 'text-' + createId()
+    let container = document.createElement("div")
+    container.classList.add("opc-control")
+
+    let label = document.createElement("label")
+    label.setAttribute("for", id)
+    label.textContent = option.name
+
+    const textInput = document.createElement("input")
+    textInput.id = id
+    textInput.type = "text"
+    textInput.maxLength = option.max
+    textInput.minLength = 0
+    textInput.placeholder = option.placeholder
+    textInput.value = option.value
+
+    textInput.addEventListener('input', () => {
+      OPC.set(option.name, textInput.value)
+    })
+
+    opcControlEvents[option.name] ||= []
+    opcControlEvents[option.name].push((v) => {
+      textInput.value = v
+    })
+
+    container.appendChild(label)
+    container.appendChild(textInput)
+    controlsElem.appendChild(container)
+  }
+
+  let _opcCreateColorPicker = (option, controlsElem) => {
+    let id = 'text-' + createId()
+    let container = document.createElement("div")
+    container.classList.add("opc-control")
+
+    let label = document.createElement("label")
+    label.setAttribute("for", id)
+    label.textContent = option.name
+
+    const colorInput = document.createElement("input")
+    colorInput.id = id
+    colorInput.type = "color"
+    colorInput.value = option.value
+
+    colorInput.addEventListener('input', () => {
+      OPC.set(option.name, colorInput.value)
+    })
+
+    // TODO: Implement sync back of color variable. May be tricky for non RGB schemes
+    container.appendChild(label)
+    container.appendChild(colorInput)
+    controlsElem.appendChild(container)
+  }
+
+  let _opcCreateButton = (option, controlsElem) => {
+    let id = 'text-' + createId()
+    let container = document.createElement("div")
+    container.classList.add("opc-control")
+
+    const buttonElem = document.createElement("input")
+    buttonElem.id = id
+    buttonElem.type = "button"
+    buttonElem.value = option.value
+
+    buttonElem.addEventListener('touchstart', () => {
+      OPC.buttonPressed(option.name, buttonElem.value)
+    })
+    buttonElem.addEventListener('mousedown', () => {
+      OPC.buttonPressed(option.name, buttonElem.value)
+    })
+    buttonElem.addEventListener('touchend', () => {
+      OPC.buttonReleased(option.name, buttonElem.value)
+    })
+    buttonElem.addEventListener('click', () => {
+      OPC.buttonReleased(option.name, buttonElem.value)
+    })
+
+    container.appendChild(buttonElem)
+    controlsElem.appendChild(container)
+  }
+
+  let _opcCreatePalettePicker = (option, controlsElem) => {
+    let id = 'text-' + createId()
+    let container = document.createElement("div")
+    container.classList.add("opc-control")
+
+    let label = document.createElement("label")
+    label.setAttribute("for", id)
+    label.textContent = option.name
+
+    let selected = option.options.indexOf(option.value)
+
+    const paletteElem = document.createElement("div")
+    paletteElem.classList.add("opc-palette-container")
+    let palettes = []
+    for (let palette of option.options) {
+      let paletteContainer = document.createElement("div")
+      paletteContainer.classList.add("opc-palette")
+      if (option.value === palette) {
+        paletteContainer.classList.add("active")
+      }
+      for (let color of palette) {
+        let colorElem = document.createElement("div")
+        colorElem.classList.add("opc-palette-color")
+        colorElem.style.backgroundColor = color
+        paletteContainer.append(colorElem)
+        colorElem.addEventListener
+      }
+      palettes.push(paletteContainer)
+      paletteContainer.addEventListener('click', () => {
+        selected = (selected + 1) % option.options.length
+        for (let p of palettes) {
+          p.classList.remove("active")
+        }
+        palettes[selected].classList.add("active")
+        OPC.set(option.name, option.options[selected])
+      })
+      paletteElem.append(paletteContainer)
+    }
+
+    // TODO: Implement sync back of palette variable
+    container.appendChild(label)
+    container.appendChild(paletteElem)
+    controlsElem.appendChild(container)
+  }
+
+  window.addEventListener('message', (event) => {
+    try {
+      if (event.data && event.data.messageType === 'OPC') {
+        let listeners = opcControlEvents[event.data.message.name]
+        if (listeners) {
+          for (let listener of listeners) {
+            listener(event.data.message.value)
+          }
+        }
+      }
+    } catch {
+      // No-op - ignore error
+    }
+  })
+
+  // Decorate OPC functions
+  _opcInitVariable = OPC.initVariable
+  OPC.initVariable = (option) => {
+    delay(() => {
+      _opcInitVariable.call(OPC, option)
+      switch (option.type) {
+        case "slider":
+          _opcCreateSlider(option, controlsElem)
+          break
+        case "toggle":
+          _opcCreateToggle(option, controlsElem)
+          break
+        case "text":
+          _opcCreateText(option, controlsElem)
+          break
+        case "color":
+          _opcCreateColorPicker(option, controlsElem)
+          break
+        case "button":
+          _opcCreateButton(option, controlsElem)
+          break
+        case "palette":
+          _opcCreatePalettePicker(option, controlsElem)
+          break
+        default:
+          console.warn(`OPC Control type ${option.type} not supported`)
+      }
+    })
+  }
+}


### PR DESCRIPTION
This contains a new standalone OPC client, to be able to add to local P5 sketches (must add the `opc.js` file as well before the client), with a minimal implementation that doesn't depend on any framework or pre assumption, unlike the Vue implementation for OP.

It works with the current implementation of opc, as tested standalone and with the OP sketch https://openprocessing.org/sketch/1946450, but also adds support for the new options object API of the controllers (see https://github.com/msawired/OPC/pull/7) as tested with the sketch https://openprocessing.org/sketch/1946498 - the standalone library displays labels and description texts, but the OP Vue client displays its current functionality.

## Usage

Just include the client file after loading P5 and OPC

```
  <script src="path/to/p5.js"></script>
  <script src="path/to/opc.js"></script>
  <script src="path/to/opc-client.js"></script>
  <script src="mySketch.js"></script>
```

OPC controls API is unchanged

## Features and Limitations

It includes the following controls:

* Slider:
  * It uses native web `range` and `number` inputs, and these are synced back and forth (changes in the variable in the sketch are reflected back in the controls)
* Toggle:
  * Uses a native web checkbox, and value is synced with sketch variable
* Palette:
  * Uses `div` elements. This could be replaced or superseded in the future for a `select` component if accessibility is an issue. This variable is not synced back with the value in the sketch
* Color:
  * Uses native `color` input. The value is **not** synced back with the value in the sketch for the time being, as color elements in P5 are more complex than an hex string
* Text:
  * Uses a native `text` input. The value is synced back with the value in the sketch.
* Button:
  * Uses a native button element, with `pressed` and `released` events

Note: The controls can be loaded in an OP sketch as demonstrated by the above mentioned sketches, but in OP the value from the sketch is **not** synced back to the editor, due to cross frame issues as it uses window messages for doing so. It only works in the standalone version, assuming the sketch is in the same domain and window as the scripts.

The implementation is minimal and contains inline CSS (in order to not require an external css), but a future improvement could be separate the CSS into its own file, and/or allow customization. Design is definitely an area of improvement, as the implementation is very barebones (and I'm not a designer x_x)

## Screenshots

Simple version
![image](https://github.com/msawired/OPC/assets/47891/249d99ad-0360-4cc0-bc67-031a6a65baa8)

Using labels and description texts (intentionally long for testing)

![image](https://github.com/msawired/OPC/assets/47891/99ff3c16-ec7c-489f-bab9-ad0cf5ea9c7f)
